### PR TITLE
Avoid NPE if grid column was removed and setVisible is called afterwards

### DIFF
--- a/vaadin-grid-util/src/main/java/org/vaadin/gridutil/cell/GridCellFilter.java
+++ b/vaadin-grid-util/src/main/java/org/vaadin/gridutil/cell/GridCellFilter.java
@@ -100,8 +100,10 @@ public class GridCellFilter implements Serializable {
 			} else {
 				clearAllFilters();
 				for (Entry<Object, CellFilterComponent<?>> entry : this.cellFilters.entrySet()) {
-					this.filterHeaderRow.getCell(entry.getKey())
-							.setText("");
+					if (null != this.filterHeaderRow.getCell(entry.getKey())) {
+						this.filterHeaderRow.getCell(entry.getKey())
+								.setText("");
+					}
 				}
 				this.grid.removeHeaderRow(this.filterHeaderRow);
 			}
@@ -193,10 +195,12 @@ public class GridCellFilter implements Serializable {
 		this.cellFilters.put(columnId, cellFilter);
 		cellFilter.getComponent()
 				.setWidth(100, Unit.PERCENTAGE);
-		this.filterHeaderRow.getCell(columnId)
-				.setComponent(cellFilter.getComponent());
-		this.filterHeaderRow.getCell(columnId)
-				.setStyleName("filter-header");
+		if(null != this.filterHeaderRow.getCell(columnId)) {
+			this.filterHeaderRow.getCell(columnId)
+					.setComponent(cellFilter.getComponent());
+			this.filterHeaderRow.getCell(columnId)
+					.setStyleName("filter-header");
+		}
 	}
 
 	/**


### PR DESCRIPTION
Avoid NPE if Grid#removeColumn(Object propertyId) was called and
GridCellFilter#setVisible(final boolean visibile) is called afterwards