### PR TITLE
Filter multi-property column according to valueProvider without propertyId

### DIFF
--- a/vaadin-grid-util/src/main/java/org/vaadin/gridutil/cell/GridCellFilter.java
+++ b/vaadin-grid-util/src/main/java/org/vaadin/gridutil/cell/GridCellFilter.java
@@ -2,6 +2,7 @@ package org.vaadin.gridutil.cell;
 
 import com.vaadin.data.BeanPropertySet;
 import com.vaadin.data.PropertySet;
+import com.vaadin.data.ValueProvider;
 import com.vaadin.data.converter.LocalDateToDateConverter;
 import com.vaadin.data.provider.InMemoryDataProviderHelpers;
 import com.vaadin.data.provider.ListDataProvider;
@@ -219,9 +220,20 @@ public class GridCellFilter<T> implements Serializable {
         for (Entry<String, SerializablePredicate> entry :
                 assignedFilters.entrySet()) {
             final String columnId = entry.getKey();
-            SerializablePredicate<T> singleFilter = InMemoryDataProviderHelpers.createValueProviderFilter(propertySet.getProperty(columnId)
-                    .get()
-                    .getGetter(), entry.getValue());
+
+            ValueProvider<T, ?> provider = null;
+            try {
+                provider = propertySet.getProperty(columnId).get().getGetter();
+            } catch (Exception e) {
+                try {
+                    provider = grid.getColumn(columnId).getValueProvider();
+                }catch (Exception ex){
+                    e.printStackTrace();
+                    ex.printStackTrace();
+                }
+            }
+
+            SerializablePredicate<T> singleFilter = InMemoryDataProviderHelpers.createValueProviderFilter(provider, entry.getValue());
             if (filter == null) {
                 filter = singleFilter;
             } else {

--- a/vaadin-grid-util/src/main/java/org/vaadin/gridutil/cell/GridCellFilter.java
+++ b/vaadin-grid-util/src/main/java/org/vaadin/gridutil/cell/GridCellFilter.java
@@ -230,6 +230,7 @@ public class GridCellFilter<T> implements Serializable {
                 }catch (Exception ex){
                     e.printStackTrace();
                     ex.printStackTrace();
+                    throw e;
                 }
             }
 


### PR DESCRIPTION
Filter only used with one property o Object. If value provider generates multi-property column this situation cannot resolve. If propertyId not fount value provider of column can be run with serializable predicate.